### PR TITLE
Minor changes

### DIFF
--- a/src/examples/louvre-views/src/Keyboard.cpp
+++ b/src/examples/louvre-views/src/Keyboard.cpp
@@ -165,20 +165,19 @@ void Keyboard::keyEvent(const LKeyboardKeyEvent &event)
 
             case KEY_PAGEDOWN:
             {
-                Surface *s = (Surface*)focus();
-                if (s && s->tl()) s->tl()->setMinimizedRequest();
+                if (seat()->activeToplevel())
+                    seat()->activeToplevel()->setMinimizedRequest();
                 return;
             }
 
             case KEY_PAGEUP:
             {
-                Surface *s = (Surface*)focus();
-                if (s && s->tl()) {
-                    if (s->tl()->maximized()) {
-                        s->tl()->unsetMaximizedRequest();
-                    } else {
-                        s->tl()->setMaximizedRequest();
-                    }
+                if (seat()->activeToplevel())
+                {
+                    if (seat()->activeToplevel()->maximized())
+                        seat()->activeToplevel()->unsetMaximizedRequest();
+                    else
+                        seat()->activeToplevel()->setMaximizedRequest();
                 }
                 return;
             }

--- a/src/examples/louvre-views/src/Pointer.cpp
+++ b/src/examples/louvre-views/src/Pointer.cpp
@@ -80,34 +80,29 @@ void Pointer::pointerMoveEvent(const LPointerMoveEvent &event)
         cursor()->setCursor(static_cast<LSurfaceView*>(G::scene()->pointerFocus().back())->surface()->client()->lastCursorRequest());
 }
 
-bool Pointer::maybeMoveOrResize(const LPointerButtonEvent &event) {
-    if (event.state() != LPointerButtonEvent::Pressed) return false;
-    if (!seat()->keyboard()->isKeyCodePressed(KEY_LEFTMETA)) return false;
-    if (!(event.button() == LPointerButtonEvent::Left ||
-          event.button() == LPointerButtonEvent::Right)) return false;
+bool Pointer::maybeMoveOrResize(const LPointerButtonEvent &event)
+{
+    if (!focus()
+        || event.state() != LPointerButtonEvent::Pressed
+        || !seat()->keyboard()->isKeyCodePressed(KEY_LEFTMETA)
+        || !(event.button() == LPointerButtonEvent::Left || event.button() == LPointerButtonEvent::Right))
+        return false;
 
-    LPointF mpos { cursor()->pos() };
+    Toplevel *toplevel { focus()->toplevel() ?
+        static_cast<Toplevel*>(focus()->toplevel()) :
+        static_cast<Surface*>(focus())->closestToplevelParent() };
 
-    // XXX: I have the feeling there's a simpler way to find the Toplevel
-    // object, but this works.
-    LView *view { G::scene()->viewAt(mpos, LView::UndefinedType, LScene::InputFilter::Pointer) };
-    Toplevel *toplevel { nullptr };
-    if (view && view->type() == LView::SurfaceType) {
-        Surface *surface = dynamic_cast<Surface*>( static_cast<LSurfaceView*>(view)->surface() );
-        while (surface) {
-            if ((toplevel = surface->tl())) break;
-            surface = (Surface*)surface->parent();
-            if (surface && surface->views().size() > 0)
-                view = surface->views()[0];
-        }
-    }
-    if (!toplevel) return false;
+    if (!toplevel || toplevel->fullscreen() || toplevel->resizeSession().isActive() || toplevel->moveSession().isActive())
+        return false;
 
+    const LPointF mpos { cursor()->pos() };
+    LView *view { toplevel->surf()->getView() };
     LBitset<LEdge> anchor { 0 };
     LXCursor *cursor { G::cursors().move };
 
     // Meta + Right Click to resize window
-    if (event.button() == LPointerButtonEvent::Right) {
+    if (event.button() == LPointerButtonEvent::Right)
+    {
         LPointF vpos { view->pos() };
         LSizeF vsz { view->size() };
 
@@ -117,84 +112,80 @@ bool Pointer::maybeMoveOrResize(const LPointerButtonEvent &event) {
             anchor = LEdgeTop | LEdgeLeft;
             cursor = G::cursors().top_left_corner;
         }
-        if (mpos.x() >= vpos.x() + 0.3333f * vsz.x() && mpos.x() < vpos.x() + 0.6666f * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.0000f * vsz.y() && mpos.y() < vpos.y() + 0.3333f * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.3333f * vsz.x() && mpos.x() < vpos.x() + 0.6666f * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.0000f * vsz.y() && mpos.y() < vpos.y() + 0.3333f * vsz.y())
         {
             anchor = LEdgeTop;
             cursor = G::cursors().top_side;
         }
-        if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.0000f * vsz.y() && mpos.y() < vpos.y() + 0.3333f * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.0000f * vsz.y() && mpos.y() < vpos.y() + 0.3333f * vsz.y())
         {
             anchor = LEdgeTop | LEdgeRight;
             cursor = G::cursors().top_right_corner;
         }
-        if (mpos.x() >= vpos.x() + 0.0000f * vsz.x() && mpos.x() < vpos.x() + 0.3333f * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.3333f * vsz.y() && mpos.y() < vpos.y() + 0.6666f * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.0000f * vsz.x() && mpos.x() < vpos.x() + 0.3333f * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.3333f * vsz.y() && mpos.y() < vpos.y() + 0.6666f * vsz.y())
         {
             anchor = LEdgeLeft;
             cursor = G::cursors().left_side;
         }
-        if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.3333f * vsz.y() && mpos.y() < vpos.y() + 0.6666f * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.3333f * vsz.y() && mpos.y() < vpos.y() + 0.6666f * vsz.y())
         {
             anchor = LEdgeRight;
             cursor = G::cursors().right_side;
         }
-        if (mpos.x() >= vpos.x() + 0.0000f * vsz.x() && mpos.x() < vpos.x() + 0.3333f * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.0000f * vsz.x() && mpos.x() < vpos.x() + 0.3333f * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
         {
             anchor = LEdgeBottom | LEdgeLeft;
             cursor = G::cursors().bottom_left_corner;
         }
-        if (mpos.x() >= vpos.x() + 0.3333f * vsz.x() && mpos.x() < vpos.x() + 0.6666f * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.3333f * vsz.x() && mpos.x() < vpos.x() + 0.6666f * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
         {
             anchor = LEdgeBottom;
             cursor = G::cursors().bottom_side;
         }
-        if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
-            mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
+        else if (mpos.x() >= vpos.x() + 0.6666f * vsz.x() && mpos.x() < vpos.x() + 1 * vsz.x() &&
+                 mpos.y() >= vpos.y() + 0.6666f * vsz.y() && mpos.y() < vpos.y() + 1 * vsz.y())
         {
             anchor = LEdgeBottom | LEdgeRight;
             cursor = G::cursors().bottom_right_corner;
         }
     }
 
-    if (cursor) {
-        G::compositor()->cursor()->setTextureB(cursor->texture(), cursor->hotspotB());
-        this->cursorOwner = view;
-    }
+    Louvre::cursor()->setCursor(cursor);
+    cursorOwner = view;
 
-    if (anchor) {
+    if (anchor)
         toplevel->startResizeRequest(event, anchor);
-    } else {
+    else
         toplevel->startMoveRequest(event);
-    }
 
     return true;
 }
 
 void Pointer::pointerButtonEvent(const LPointerButtonEvent &event)
 {
-    if (maybeMoveOrResize(event)) {
-        this->isDragging = true;
-        return;
-    }
+    if (maybeMoveOrResize(event))
+        G::scene()->handlePointerButtonEvent(event, 0);
+    else
+        G::scene()->handlePointerButtonEvent(event);
 
-    if (event.state() == LPointerButtonEvent::Released)
+    if (event.state() == LPointerButtonEvent::Released
+        && seat()->toplevelResizeSessions().empty()
+        && seat()->toplevelMoveSessions().empty())
     {
-        if (this->isDragging) {
-            this->isDragging = false;
-            G::compositor()->cursor()->useDefault();
-        }
+        G::compositor()->cursor()->useDefault();
         G::enableDocks(true);
         G::compositor()->updatePointerBeforePaint = true;
     }
 
-    G::scene()->handlePointerButtonEvent(event);
-
-    if (G::compositor()->wofi && G::compositor()->wofi->client && G::compositor()->wofi && !G::scene()->pointerFocus().empty() && G::scene()->pointerFocus().front()->userData() == WallpaperType)
+    if (G::compositor()->wofi && G::compositor()->wofi->client
+        && G::compositor()->wofi && !G::scene()->pointerFocus().empty()
+        && G::scene()->pointerFocus().front()->userData() == WallpaperType)
         G::compositor()->wofi->client->destroyLater();
 }
 

--- a/src/examples/louvre-views/src/Pointer.h
+++ b/src/examples/louvre-views/src/Pointer.h
@@ -2,6 +2,7 @@
 #define POINTER_H
 
 #include <LPointer.h>
+#include <LWeak.h>
 
 using namespace Louvre;
 
@@ -14,9 +15,7 @@ public:
     void pointerScrollEvent(const LPointerScrollEvent &event) override;
     void setCursorRequest(const LClientCursor &clientCursor) override;
     bool maybeMoveOrResize(const LPointerButtonEvent &event);
-
-    LView *cursorOwner { nullptr };
-    bool isDragging { false };
+    LWeak<LView> cursorOwner;
 };
 
 #endif // POINTER_H

--- a/src/examples/louvre-views/src/Surface.cpp
+++ b/src/examples/louvre-views/src/Surface.cpp
@@ -105,6 +105,20 @@ Surface *Surface::searchSessionLockParent(Surface *parent)
     return nullptr;
 }
 
+Toplevel *Surface::closestToplevelParent() const noexcept
+{
+    const LSurface *surface { this };
+
+    while (surface->parent())
+    {
+        if (surface->parent()->toplevel())
+            return static_cast<class Toplevel*>(surface->parent()->toplevel());
+        surface = surface->parent();
+    }
+
+    return nullptr;
+}
+
 LView *Surface::getView() const
 {
     if (tl() && tl()->decoratedView)

--- a/src/examples/louvre-views/src/Surface.h
+++ b/src/examples/louvre-views/src/Surface.h
@@ -23,6 +23,7 @@ public:
     class Toplevel *tl() const {return (class Toplevel*)toplevel();}
 
     static class Surface *searchSessionLockParent(Surface *parent);
+    class Toplevel *closestToplevelParent() const noexcept;
 
     LView *getView() const;
 

--- a/src/lib/core/LCursor.h
+++ b/src/lib/core/LCursor.h
@@ -131,6 +131,8 @@ public:
 
     /**
      * @brief Assigns an LXCursor.
+     *
+     * @note Passing `nullptr` is a no-op.
      */
     void setCursor(const LXCursor *xcursor) noexcept;
 

--- a/src/lib/core/scene/LScene.cpp
+++ b/src/lib/core/scene/LScene.cpp
@@ -393,11 +393,10 @@ retry:
         return;
     }
 
-    // Left button pressed
     if (event.state() == LPointerButtonEvent::Pressed)
     {
         // Keep a ref to continue sending it events after the cursor
-        // leaves, if the left button remains pressed
+        // leaves, if the button remains pressed
         pointer.setDraggingSurface(seat()->pointer()->focus());
 
         if (!keyboard.focus() || !pointer.focus()->isSubchildOf(keyboard.focus()))
@@ -425,7 +424,7 @@ retry:
         else
             pointer.focus()->raise();
     }
-    // Left button released
+    // Button released
     else
     {
         pointer.sendButtonEvent(event);


### PR DESCRIPTION
I have to say that everything works perfectly! Great job! :D 

I just made some small changes, such as replacing the `LScene::viewAt()` call with `Pointer::focus()` and adding a new `Surface::closestToplevelParent()` method to find the parent toplevel if the surface has another role.

There was another option as well. Each time a pointer move event is handled by `LScene`, it updates the `LScene::pointerFocus()` vector. Usually, it only contains a single view or none, but views can enable pass-through when `LView::blockPointerEnabled ()` is set to false.

Also, finishing interactive toplevel sessions (which can be accessed from `LSeat`) by releasing any pointer button works fine. This could later be improved by checking if their `triggeringEvent()` matches the released button. I didn't implement that yet because some clients sometimes request starting sessions by providing a `keyboardEnter` event, which would require additional validations in the request handlers.